### PR TITLE
Add two explicit deps to pom.xml for iot-software-sensor

### DIFF
--- a/components/iot-software-sensor-quarkus/pom.xml
+++ b/components/iot-software-sensor-quarkus/pom.xml
@@ -26,6 +26,10 @@
     </properties>
 
     <dependencies>
+		<dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+		</dependency>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-paho</artifactId>

--- a/components/iot-software-sensor/pom.xml
+++ b/components/iot-software-sensor/pom.xml
@@ -25,10 +25,17 @@
 	</properties>
 
 	<dependencies>
+		<!-- mhjacks added 3/8/2022 -->
+		<dependency>
+    		<groupId>com.fasterxml</groupId>
+    		<artifactId>classmate</artifactId>
+		</dependency>
+
 		<dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
 		</dependency>
+		<!-- end mhjacks added 3/8/2022 -->
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/components/iot-software-sensor/pom.xml
+++ b/components/iot-software-sensor/pom.xml
@@ -26,6 +26,11 @@
 
 	<dependencies>
 		<dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>


### PR DESCRIPTION
The machine-sensor pods started going into crashloopbackoff status as documented in https://github.com/hybrid-cloud-patterns/industrial-edge/issues/75.  This adds dependencies that eliminate those errors and allow the software to rebuild correctly.